### PR TITLE
Change callback name to match defined handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export default function App() {
 
   return (
     <EmojiPicker
-      onEmojiSelected={handleSelect}
+      onEmojiSelected={handlePick}
       open={isOpen}
       onClose={() => setIsOpen(false)} />
   )


### PR DESCRIPTION
I think it should be `handlePick` instead of `handleSelect` that doesn't appear anywhere else.

Feel free to close this PR if that was the intention