### PR TITLE
Feature / disable Safe Area

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ export default function App() {
 | disabledCategories | CategoryTypes[] | [] | no | Hide categories by passing their slugs |
 | categoryOrder | CategoryTypes[] | [] | no | Set category sequence |
 | onRequestClose | function | undefined | no | Handle onRequestClose in modal |
+| categoryContainerStyles | ViewStyle | {} | no | Override category container styles |
+| disableSafeArea | boolean | false | no | Disable safe area inside modal |
 
 ## 📊 Comparison
 

--- a/example/ios/EmojiKeyboardExample.xcodeproj/project.pbxproj
+++ b/example/ios/EmojiKeyboardExample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		23EF9C852745ABE10087B899 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EF9C842745ABE10087B899 /* empty.swift */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
@@ -47,6 +48,8 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = EmojiKeyboardExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = EmojiKeyboardExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = EmojiKeyboardExample/main.m; sourceTree = "<group>"; };
+		23EF9C832745ABE00087B899 /* EmojiKeyboardExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmojiKeyboardExample-Bridging-Header.h"; sourceTree = "<group>"; };
+		23EF9C842745ABE10087B899 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* EmojiKeyboardExample-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EmojiKeyboardExample-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* EmojiKeyboardExample-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "EmojiKeyboardExample-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		47F7ED3B7971BE374F7B8635 /* Pods-EmojiKeyboardExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EmojiKeyboardExample.debug.xcconfig"; path = "Target Support Files/Pods-EmojiKeyboardExample/Pods-EmojiKeyboardExample.debug.xcconfig"; sourceTree = "<group>"; };
@@ -117,6 +120,8 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				23EF9C842745ABE10087B899 /* empty.swift */,
+				23EF9C832745ABE00087B899 /* EmojiKeyboardExample-Bridging-Header.h */,
 			);
 			name = EmojiKeyboardExample;
 			sourceTree = "<group>";
@@ -137,7 +142,6 @@
 				47F7ED3B7971BE374F7B8635 /* Pods-EmojiKeyboardExample.debug.xcconfig */,
 				E00ACF0FDA8BF921659E2F9A /* Pods-EmojiKeyboardExample.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -267,7 +271,8 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						LastSwiftMigration = 1120;
+						DevelopmentTeam = CKHD27966K;
+						LastSwiftMigration = 1310;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -477,6 +482,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				23EF9C852745ABE10087B899 /* empty.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -516,6 +522,7 @@
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -538,6 +545,7 @@
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = EmojiKeyboardExampleTests/Info.plist;
@@ -561,6 +569,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CKHD27966K;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = EmojiKeyboardExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -571,6 +580,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.reactnativeemojikeyboard;
 				PRODUCT_NAME = EmojiKeyboardExample;
+				SWIFT_OBJC_BRIDGING_HEADER = "EmojiKeyboardExample-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -584,6 +594,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CKHD27966K;
 				INFOPLIST_FILE = EmojiKeyboardExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -593,6 +604,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.reactnativeemojikeyboard;
 				PRODUCT_NAME = EmojiKeyboardExample;
+				SWIFT_OBJC_BRIDGING_HEADER = "EmojiKeyboardExample-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/example/ios/empty.swift
+++ b/example/ios/empty.swift
@@ -1,0 +1,6 @@
+//
+//  empty.swift
+//  EmojiKeyboardExample
+//
+//  Created by Jakub Grzywacz on 17/11/2021.
+//

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -17,6 +17,7 @@ export const Categories = () => {
     categoryPosition,
     renderList,
     setActiveCategoryIndex,
+    categoryContainerStyles,
   } = React.useContext(KeyboardContext)
   const scrollNav = React.useRef(new Animated.Value(0)).current
   const handleScrollToCategory = React.useCallback(
@@ -57,7 +58,7 @@ export const Categories = () => {
   )
 
   const getStylesBasedOnPosition = () => {
-    const style: ViewStyle[] = [styles.navigation]
+    const style: ViewStyle[] = [styles.navigation, categoryContainerStyles]
     switch (categoryPosition) {
       case 'floating':
         style.push(styles.navigationFloating)

--- a/src/components/ConditionalContainer.tsx
+++ b/src/components/ConditionalContainer.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode } from 'react'
+import { SafeAreaView, View, ViewProps } from 'react-native'
+
+type ConditionalContainerTypes = {
+  children: ReactNode
+  container: (children: ReactNode) => ReactNode
+  condition: boolean
+}
+export const ConditionalContainer = ({
+  children,
+  container,
+  condition,
+}: ConditionalContainerTypes) => <>{condition ? container(children) : children}</>
+
+type IsSafeAreaWrapperProps = {
+  children: ReactNode
+  isSafeArea: boolean
+} & ViewProps
+export const IsSafeAreaWrapper = ({ children, isSafeArea, ...props }: IsSafeAreaWrapperProps) =>
+  isSafeArea ? (
+    <SafeAreaView {...props}>{children}</SafeAreaView>
+  ) : (
+    <View {...props}>{children}</View>
+  )

--- a/src/components/EmojiStaticKeyboard.tsx
+++ b/src/components/EmojiStaticKeyboard.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react'
 
-import { StyleSheet, View, FlatList, useWindowDimensions, Animated } from 'react-native'
+import {
+  StyleSheet,
+  View,
+  FlatList,
+  useWindowDimensions,
+  Animated,
+  SafeAreaView,
+} from 'react-native'
 import type { CategoryTypes, EmojisByCategory } from '../types'
 import { EmojiCategory } from './EmojiCategory'
 import { KeyboardContext } from '../contexts/KeyboardContext'
 import { Categories } from './Categories'
 import { SearchBar } from './SearchBar'
 import { useKeyboardStore } from '../store/useKeyboardStore'
+import { ConditionalContainer } from './ConditionalContainer'
 
 export const EmojiStaticKeyboard = () => {
   const { width } = useWindowDimensions()
@@ -18,6 +26,7 @@ export const EmojiStaticKeyboard = () => {
     enableSearchBar,
     searchPhrase,
     renderList,
+    disableSafeArea,
   } = React.useContext(KeyboardContext)
   const { keyboardState } = useKeyboardStore()
   const flatListRef = React.useRef<FlatList>(null)
@@ -41,34 +50,46 @@ export const EmojiStaticKeyboard = () => {
       style={[
         styles.container,
         styles.containerShadow,
-        categoryPosition === 'top' && styles.containerReverse,
+        categoryPosition === 'top' && disableSafeArea && styles.containerReverse,
         containerStyles,
       ]}>
-      {enableSearchBar && <SearchBar />}
-      <Animated.FlatList
-        extraData={[keyboardState.recentlyUsed.length, searchPhrase]}
-        data={renderList}
-        keyExtractor={(item: EmojisByCategory) => item.title}
-        renderItem={renderItem}
-        removeClippedSubviews={true}
-        ref={flatListRef}
-        onScrollToIndexFailed={onCategoryChangeFailed}
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        pagingEnabled
-        scrollEventThrottle={16}
-        getItemLayout={getItemLayout}
-        scrollEnabled={false}
-        initialNumToRender={1}
-        windowSize={2}
-        maxToRenderPerBatch={1}
-      />
-      <Categories />
+      <ConditionalContainer
+        condition={!disableSafeArea}
+        container={(children) => (
+          <SafeAreaView
+            style={[styles.flex, categoryPosition === 'top' && styles.containerReverse]}>
+            {children}
+          </SafeAreaView>
+        )}>
+        <>
+          {enableSearchBar && <SearchBar />}
+          <Animated.FlatList
+            extraData={[keyboardState.recentlyUsed.length, searchPhrase]}
+            data={renderList}
+            keyExtractor={(item: EmojisByCategory) => item.title}
+            renderItem={renderItem}
+            removeClippedSubviews={true}
+            ref={flatListRef}
+            onScrollToIndexFailed={onCategoryChangeFailed}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            pagingEnabled
+            scrollEventThrottle={16}
+            getItemLayout={getItemLayout}
+            scrollEnabled={false}
+            initialNumToRender={1}
+            windowSize={2}
+            maxToRenderPerBatch={1}
+          />
+          <Categories />
+        </>
+      </ConditionalContainer>
     </View>
   )
 }
 
 const styles = StyleSheet.create({
+  flex: { flex: 1 },
   container: {
     flex: 1,
     borderRadius: 16,

--- a/src/components/ModalWithBackdrop.tsx
+++ b/src/components/ModalWithBackdrop.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {
-  SafeAreaView,
   Modal,
   Animated,
   useWindowDimensions,
@@ -11,6 +10,7 @@ import {
 } from 'react-native'
 import { KeyboardContext } from '../contexts/KeyboardContext'
 import { useTimeout } from '../hooks/useTimeout'
+import { IsSafeAreaWrapper } from './ConditionalContainer'
 
 type ModalWithBackdropProps = {
   isOpen: boolean
@@ -26,7 +26,7 @@ export const ModalWithBackdrop = ({
 }: ModalWithBackdropProps & ModalProps) => {
   const { height: screenHeight } = useWindowDimensions()
   const translateY = React.useRef(new Animated.Value(screenHeight)).current
-  const { backdropColor } = React.useContext(KeyboardContext)
+  const { backdropColor, disableSafeArea } = React.useContext(KeyboardContext)
   const handleTimeout = useTimeout()
 
   React.useEffect(() => {
@@ -48,7 +48,7 @@ export const ModalWithBackdrop = ({
     <Modal visible={isOpen} animationType="fade" transparent={true} {...rest}>
       <TouchableOpacity style={styles.modalContainer} activeOpacity={1} onPress={handleClose}>
         <View style={[styles.modalContainer, { backgroundColor: backdropColor }]}>
-          <SafeAreaView style={styles.modalContainer}>
+          <IsSafeAreaWrapper style={styles.modalContainer} isSafeArea={!disableSafeArea}>
             <TouchableOpacity activeOpacity={1}>
               <Animated.View
                 style={{
@@ -57,7 +57,7 @@ export const ModalWithBackdrop = ({
                 {children}
               </Animated.View>
             </TouchableOpacity>
-          </SafeAreaView>
+          </IsSafeAreaWrapper>
         </View>
       </TouchableOpacity>
     </Modal>

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -44,6 +44,8 @@ export type KeyboardProps = {
   searchBarPlaceholderColor?: string
   categoryOrder?: CategoryTypes[]
   onRequestClose?: () => void
+  categoryContainerStyles?: ViewStyle
+  disableSafeArea?: boolean
 }
 export type ContextValues = {
   activeCategoryIndex: number

--- a/src/contexts/KeyboardProvider.tsx
+++ b/src/contexts/KeyboardProvider.tsx
@@ -43,6 +43,8 @@ export const defaultKeyboardContext: Required<KeyboardProps> = {
   searchBarPlaceholderColor: '#00000055',
   categoryOrder: [...CATEGORIES],
   onRequestClose: () => {},
+  categoryContainerStyles: {},
+  disableSafeArea: false,
 }
 
 export const defaultKeyboardValues: ContextValues = {


### PR DESCRIPTION
Added two new props.
Now you can disable safe area if you want to customize space under keyboard.
*If needed you can add custom `categoryContainerStyles` (like marginBottom) and push categories up*
| Name | Type | Default Value | Required | Description |
|---|---|---|---|---|
| categoryContainerStyles | ViewStyle | {} | no | Override category container styles |
| disableSafeArea | boolean | false | no | Disable safe area inside modal |

Closes #42 

*Also added bridging header to fix ios example app*