### PR TITLE
chore: bump minSdkVersion in example project

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }


### PR DESCRIPTION
bump minSdkVersion in example project to get android simulators working