### PR TITLE
fix: problem with search results not displaying

### DIFF
--- a/src/components/EmojiCategory.tsx
+++ b/src/components/EmojiCategory.tsx
@@ -125,12 +125,8 @@ export const EmojiCategory = React.memo(
     )
   },
   (prevProps, nextProps) => {
-    if (nextProps.item.title !== 'search') {
-      return true
-    }
-    if (prevProps.item.data.length !== nextProps.item.data.length) {
-      return false
-    }
+    if (nextProps.item.title !== 'search') return true
+    if (prevProps.item.data.length !== nextProps.item.data.length) return false
     return (
       prevProps.item.data.map((d) => d.name).join() ===
       nextProps.item.data.map((d) => d.name).join()

--- a/src/components/EmojiCategory.tsx
+++ b/src/components/EmojiCategory.tsx
@@ -124,7 +124,18 @@ export const EmojiCategory = React.memo(
       </View>
     )
   },
-  () => true
+  (prevProps, nextProps) => {
+    if (nextProps.item.title !== 'search') {
+      return true
+    }
+    if (prevProps.item.data.length !== nextProps.item.data.length) {
+      return false
+    }
+    return (
+      prevProps.item.data.map((d) => d.name).join() ===
+      nextProps.item.data.map((d) => d.name).join()
+    )
+  }
 )
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
I found a bug that search results are not shown.

This is because `EmojiCategory` is not re-rendered when props are changed due to `React.memo`. The second argument func of `React.memo` always return `true`.

I modified the func to re-render when category is 'search' and the data has changed. If you have a better way to check, please let me know.


| Before | After |
|:-----------:|:------------:|
|<img width="200" src="https://user-images.githubusercontent.com/4277693/188292594-ee2ec0ea-9cab-48bd-900a-2c0e91a5db48.gif" />|<img width="200" src="https://user-images.githubusercontent.com/4277693/188292596-3f945084-0ec3-4563-98d4-dda672227d05.gif" />|
