### PR TITLE
fix: increased window size to prevent list bouncing on scroll to bottom

### DIFF
--- a/src/components/EmojiCategory.tsx
+++ b/src/components/EmojiCategory.tsx
@@ -117,7 +117,7 @@ export const EmojiCategory = React.memo(
             <View style={categoryPosition === 'floating' ? styles.footerFloating : styles.footer} />
           )}
           initialNumToRender={10}
-          windowSize={10}
+          windowSize={16}
           maxToRenderPerBatch={5}
           keyboardShouldPersistTaps="handled"
         />


### PR DESCRIPTION
closes https://github.com/TheWidlarzGroup/rn-emoji-keyboard/issues/103

It works fine for me with windowSize=14, but I've left some bufor.