### PR TITLE
fix: emoji disappearing on iOS back gesture during scroll animation

### DIFF
--- a/src/components/EmojiCategory.tsx
+++ b/src/components/EmojiCategory.tsx
@@ -110,7 +110,6 @@ export const EmojiCategory = React.memo(
           keyExtractor={keyExtractor}
           numColumns={numberOfColumns}
           renderItem={renderItem}
-          removeClippedSubviews={true}
           getItemLayout={getItemLayout}
           onScroll={handleOnScroll}
           ListFooterComponent={() => (


### PR DESCRIPTION
closes https://github.com/TheWidlarzGroup/rn-emoji-keyboard/issues/113