### PR TITLE
Source info property addition

### DIFF
--- a/docs/docs/api/modal.md
+++ b/docs/docs/api/modal.md
@@ -33,7 +33,7 @@ Callback fired when the component is to be closed.
 ### <TitleWithRequiredBadge>`onEmojiSelected`</TitleWithRequiredBadge>
 
 Callback fired when the emoji is selected. The passed function expose an object with selected emoji data.
-It also returns `alreadySelected` boolean indicating whether pressed emoji is already selected or not (see [selectedEmojis](#selectedemojis)). 'sourceInfo' will returned as second argument to get the pressed compoent information
+It also returns `alreadySelected` boolean indicating whether pressed emoji is already selected or not (see [selectedEmojis](#selectedemojis)). 'sourceInfo' will returned as second argument to get the pressed component information
 
 <ApiTable typeVal='(emoji: { emoji, name, slug, unicode_version, alreadySelected }) => void' defaultVal='undefined'/>
 

--- a/docs/docs/api/modal.md
+++ b/docs/docs/api/modal.md
@@ -33,7 +33,7 @@ Callback fired when the component is to be closed.
 ### <TitleWithRequiredBadge>`onEmojiSelected`</TitleWithRequiredBadge>
 
 Callback fired when the emoji is selected. The passed function expose an object with selected emoji data.
-It also returns `alreadySelected` boolean indicating whether pressed emoji is already selected or not (see [selectedEmojis](#selectedemojis)). 'sourceInfo' will returned as second argument to get the pressed component information
+It also returns `alreadySelected` boolean indicating whether pressed emoji is already selected or not (see [selectedEmojis](#selectedemojis)). 'sourceInfo' will returned as the second argument to help identify which emoji component have changed.
 
 <ApiTable typeVal='(emoji: { emoji, name, slug, unicode_version, alreadySelected }) => void' defaultVal='undefined'/>
 
@@ -181,7 +181,7 @@ Look into [**internationalization section**](/docs/documentation/internationaliz
 :::
 
 #### `sourceInfo`
-send the context of the pressed component like id.
+sourceInfo help identify which emoji component have changed, specified like key. will be return in `onEmojiSelected` callback.
 
 
 <ApiTable typeVal='CategoryTranslation' defaultVal='en'/>

--- a/docs/docs/api/modal.md
+++ b/docs/docs/api/modal.md
@@ -181,7 +181,7 @@ Look into [**internationalization section**](/docs/documentation/internationaliz
 :::
 
 #### `sourceInfo`
-sourceInfo help identify which emoji component have changed, specified like key. will be return in `onEmojiSelected` callback.
+Help identify which emoji component have changed, specified like key. will be return in `onEmojiSelected` callback.
 
 
 <ApiTable typeVal='CategoryTranslation' defaultVal='en'/>

--- a/docs/docs/api/modal.md
+++ b/docs/docs/api/modal.md
@@ -181,7 +181,7 @@ Look into [**internationalization section**](/docs/documentation/internationaliz
 :::
 
 #### `sourceInfo`
-send the context of the presses emoji component like id
+send the context of the pressed component like id.
 
 
 <ApiTable typeVal='CategoryTranslation' defaultVal='en'/>

--- a/docs/docs/api/modal.md
+++ b/docs/docs/api/modal.md
@@ -33,7 +33,7 @@ Callback fired when the component is to be closed.
 ### <TitleWithRequiredBadge>`onEmojiSelected`</TitleWithRequiredBadge>
 
 Callback fired when the emoji is selected. The passed function expose an object with selected emoji data.
-It also returns `alreadySelected` boolean indicating whether pressed emoji is already selected or not (see [selectedEmojis](#selectedemojis)).
+It also returns `alreadySelected` boolean indicating whether pressed emoji is already selected or not (see [selectedEmojis](#selectedemojis)). 'sourceInfo' will returned as second argument to get the pressed compoent information
 
 <ApiTable typeVal='(emoji: { emoji, name, slug, unicode_version, alreadySelected }) => void' defaultVal='undefined'/>
 
@@ -179,5 +179,9 @@ Change the library language.
 :::tip
 Look into [**internationalization section**](/docs/documentation/internationalization) for more details about translations.
 :::
+
+#### `sourceInfo`
+send the context of the presses emoji component like id
+
 
 <ApiTable typeVal='CategoryTranslation' defaultVal='en'/>

--- a/src/EmojiPicker.tsx
+++ b/src/EmojiPicker.tsx
@@ -18,6 +18,7 @@ export const EmojiPicker = ({
   expandable = defaultKeyboardContext.expandable,
   defaultHeight = defaultKeyboardContext.defaultHeight,
   allowMultipleSelections = false,
+  sourceInfo,
   ...props
 }: KeyboardProps) => {
   const { height: screenHeight } = useWindowDimensions()

--- a/src/EmojiPicker.tsx
+++ b/src/EmojiPicker.tsx
@@ -45,13 +45,8 @@ export const EmojiPicker = ({
 
   return (
     <KeyboardProvider
-<<<<<<< Updated upstream
-      onEmojiSelected={(emoji: EmojiType) => {
-        onEmojiSelected(emoji)
-=======
       onEmojiSelected={(emoji: EmojiType, sourceInfo: any) => {
         onEmojiSelected(emoji, sourceInfo)
->>>>>>> Stashed changes
         !allowMultipleSelections && close()
       }}
       open={open}

--- a/src/EmojiPicker.tsx
+++ b/src/EmojiPicker.tsx
@@ -46,7 +46,7 @@ export const EmojiPicker = ({
 
   return (
     <KeyboardProvider
-      onEmojiSelected={(emoji: EmojiType, sourceInfo: any) => {
+      onEmojiSelected={(emoji: EmojiType) => {
         onEmojiSelected(emoji, sourceInfo)
         !allowMultipleSelections && close()
       }}

--- a/src/EmojiPicker.tsx
+++ b/src/EmojiPicker.tsx
@@ -45,8 +45,13 @@ export const EmojiPicker = ({
 
   return (
     <KeyboardProvider
+<<<<<<< Updated upstream
       onEmojiSelected={(emoji: EmojiType) => {
         onEmojiSelected(emoji)
+=======
+      onEmojiSelected={(emoji: EmojiType, sourceInfo: any) => {
+        onEmojiSelected(emoji, sourceInfo)
+>>>>>>> Stashed changes
         !allowMultipleSelections && close()
       }}
       open={open}

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -59,6 +59,7 @@ export type Theme = {
 export type KeyboardProps = {
   open: boolean
   onClose: () => void
+  sourceInfo?: any
   onEmojiSelected: OnEmojiSelected
   emojiSize?: number
   expandable?: boolean
@@ -166,6 +167,7 @@ export const defaultKeyboardContext: Required<KeyboardProps> & { theme: Theme; s
   enableCategoryChangeAnimation: true,
   selectedEmojis: false,
   enableCategoryChangeGesture: true,
+  sourceInfo: null
 }
 
 export const defaultKeyboardValues: ContextValues = {

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -14,7 +14,7 @@ import {
 } from '../types'
 import type { RecursivePartial } from '../utils/deepMerge'
 
-export type OnEmojiSelected = (emoji: EmojiType) => void
+export type OnEmojiSelected = (emoji: EmojiType, sourceInfo?: any) => void
 
 export type Styles = {
   container: ViewStyle


### PR DESCRIPTION
**Problem**: When using multiple `<EmojiComponent/>` it is necessary to identify which emoji component have changed (where was made the last emoji selection) in order to associate the appropriate context.

**Solution**: An optional property, `sourceInfo`, that be will be returned with `onEmojiSelected` callback, if passed by the `<EmojiComponent/>` caller