### PR TITLE
fix: prevent running onKeyboardWillShow when picker is closed

### DIFF
--- a/src/EmojiPicker.tsx
+++ b/src/EmojiPicker.tsx
@@ -24,7 +24,7 @@ export const EmojiPicker = ({
   const offsetY = React.useRef(new Animated.Value(0)).current
   const height = React.useRef(new Animated.Value(getHeight(defaultHeight, screenHeight))).current
   const additionalHeight = React.useRef(new Animated.Value(0)).current
-  const { keyboardVisible, keyboardHeight } = useKeyboard()
+  const { keyboardVisible, keyboardHeight } = useKeyboard(open)
   const [isExpanded, setIsExpanded] = React.useState(false)
 
   React.useEffect(() => {

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -1,28 +1,32 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Keyboard, KeyboardEvent } from 'react-native'
 
-export const useKeyboard = () => {
+export const useKeyboard = (isOpen: boolean) => {
   const [keyboardVisible, setKeyboardVisible] = useState(false)
   const [keyboardHeight, setKeyboardHeight] = useState(0)
 
-  function onKeyboardDidShow(e: KeyboardEvent) {
-    setKeyboardHeight(e.endCoordinates.height)
-    setKeyboardVisible(true)
-  }
+  const onKeyboardWillShow = useCallback(
+    (e: KeyboardEvent) => {
+      if (!isOpen) return
+      setKeyboardHeight(e.endCoordinates.height)
+      setKeyboardVisible(true)
+    },
+    [isOpen]
+  )
 
-  function onKeyboardDidHide() {
+  const onKeyboardWillHide = useCallback(() => {
     setKeyboardHeight(0)
     setKeyboardVisible(false)
-  }
+  }, [])
 
   useEffect(() => {
-    const showSubscription = Keyboard.addListener('keyboardWillShow', onKeyboardDidShow)
-    const hideSubscription = Keyboard.addListener('keyboardWillHide', onKeyboardDidHide)
+    const showSubscription = Keyboard.addListener('keyboardWillShow', onKeyboardWillShow)
+    const hideSubscription = Keyboard.addListener('keyboardWillHide', onKeyboardWillHide)
     return () => {
       showSubscription.remove()
       hideSubscription.remove()
     }
-  }, [])
+  }, [onKeyboardWillHide, onKeyboardWillShow])
 
   return { keyboardVisible, keyboardHeight }
 }


### PR DESCRIPTION
Fixes #130 

Prevent running onKeyboardWillShow when picker is closed.

Before:

https://user-images.githubusercontent.com/39670088/235342192-fcc43ad1-4d81-4c27-abd0-aa3ffa240c3a.mov

After:


https://user-images.githubusercontent.com/39670088/235342198-a03df7a5-f03a-408d-8072-aa1d60811a6e.mov

