### PR TITLE
Fix/emoji tones bugs

### DIFF
--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -20,7 +20,6 @@ export const Categories = (p: Props) => {
     onCategoryChangeFailed,
     categoryPosition,
     renderList,
-    clearEmojiTonesData,
     theme,
     styles: themeStyles,
     enableCategoryChangeAnimation,
@@ -29,9 +28,8 @@ export const Categories = (p: Props) => {
 
   const scrollNav = React.useRef(new Animated.Value(0)).current
   const handleScrollToCategory = React.useCallback(() => {
-    clearEmojiTonesData()
     setShouldAnimateScroll(enableCategoryChangeAnimation)
-  }, [clearEmojiTonesData, setShouldAnimateScroll, enableCategoryChangeAnimation])
+  }, [setShouldAnimateScroll, enableCategoryChangeAnimation])
 
   const renderItem = React.useCallback(
     ({ item, index }: { item: CategoryNavigationItem; index: number }) => (

--- a/src/components/EmojiStaticKeyboard.tsx
+++ b/src/components/EmojiStaticKeyboard.tsx
@@ -72,9 +72,16 @@ export const EmojiStaticKeyboard = React.memo(
       (el: NativeSyntheticEvent<NativeScrollEvent>) => {
         const index = el.nativeEvent.contentOffset.x / width
         scrollNav.setValue(index * CATEGORY_ELEMENT_WIDTH)
-        if (Number.isInteger(index)) setActiveCategoryIndex(index)
       },
-      [scrollNav, setActiveCategoryIndex, width]
+      [scrollNav, width]
+    )
+
+    const onScrollEnd = React.useCallback(
+      (el: NativeSyntheticEvent<NativeScrollEvent>) => {
+        const index = el.nativeEvent.contentOffset.x / width
+        setActiveCategoryIndex(Math.round(index))
+      },
+      [setActiveCategoryIndex, width]
     )
 
     return (
@@ -114,6 +121,7 @@ export const EmojiStaticKeyboard = React.memo(
               maxToRenderPerBatch={1}
               onScroll={handleScroll}
               keyboardShouldPersistTaps="handled"
+              onMomentumScrollEnd={onScrollEnd}
             />
             <Categories scrollNav={enableCategoryChangeGesture ? scrollNav : undefined} />
             <SkinTones keyboardScrollOffsetY={keyboardScrollOffsetY} />

--- a/src/components/EmojiStaticKeyboard.tsx
+++ b/src/components/EmojiStaticKeyboard.tsx
@@ -63,6 +63,7 @@ export const EmojiStaticKeyboard = React.memo(
         index: activeCategoryIndex,
         animated: shouldAnimateScroll && enableCategoryChangeAnimation,
       })
+      setKeyboardScrollOffsetY(0)
     }, [activeCategoryIndex, enableCategoryChangeAnimation, shouldAnimateScroll])
 
     const keyExtractor = React.useCallback((item: EmojisByCategory) => item.title, [])

--- a/src/contexts/KeyboardProvider.tsx
+++ b/src/contexts/KeyboardProvider.tsx
@@ -104,6 +104,10 @@ export const KeyboardProvider: React.FC<ProviderProps> = React.memo((props) => {
   const clearEmojiTonesData = () => setEmojiTonesData(null)
 
   React.useEffect(() => {
+    clearEmojiTonesData()
+  }, [activeCategoryIndex])
+
+  React.useEffect(() => {
     if (props.open) setActiveCategoryIndex(0)
     setSearchPhrase('')
     clearEmojiTonesData()


### PR DESCRIPTION
Fixed:
1. https://github.com/TheWidlarzGroup/rn-emoji-keyboard/issues/134
2. https://github.com/TheWidlarzGroup/rn-emoji-keyboard/issues/135
3. Problem on some devices with wrong category highlited (Samsung and Iphone were fine, but it's visible on my Xiaomi mi 10t lite). This `if (Number.isInteger(index)) setActiveCategoryIndex(index)` was always falsy. See video and SS.

<img width="695" alt="Screenshot 2023-05-17 at 09 44 20" src="https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/37906388/40722c15-9a28-4591-aa66-5b054046ee96">


https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/37906388/70d33548-cc63-4fbf-9cb3-bdcb0df332bd



