### PR TITLE
fix: turned off removeClippedSubview on iOS

### DIFF
--- a/src/components/EmojiStaticKeyboard.tsx
+++ b/src/components/EmojiStaticKeyboard.tsx
@@ -9,6 +9,7 @@ import {
   SafeAreaView,
   NativeSyntheticEvent,
   NativeScrollEvent,
+  Platform,
 } from 'react-native'
 import type { EmojisByCategory } from '../types'
 import { EmojiCategory } from './EmojiCategory'
@@ -20,6 +21,7 @@ import { ConditionalContainer } from './ConditionalContainer'
 import { SkinTones } from './SkinTones'
 
 const CATEGORY_ELEMENT_WIDTH = 37
+const isAndroid = Platform.OS === 'android'
 
 export const EmojiStaticKeyboard = React.memo(
   () => {
@@ -109,7 +111,7 @@ export const EmojiStaticKeyboard = React.memo(
               data={renderList}
               keyExtractor={keyExtractor}
               renderItem={renderItem}
-              removeClippedSubviews={true}
+              removeClippedSubviews={isAndroid}
               ref={flatListRef}
               onScrollToIndexFailed={onCategoryChangeFailed}
               horizontal


### PR DESCRIPTION
I had to disable removeClippedSubviews on iOS, because it makes some emojis unclickable. It was connected with Reanimated layout animations.
It works fine on Android so I decided to leave it as it was as there are usually performance issues there.
https://github.com/TheWidlarzGroup/rn-emoji-keyboard/issues/138