### PR TITLE
fix: add postinstall script to apply patch-package required for m1 mac

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,8 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "ios:ip12": "react-native run-ios --simulator='iPhone 12'"
+    "ios:ip12": "react-native run-ios --simulator='iPhone 12'",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.10",


### PR DESCRIPTION
Recently I've added patch for react-native, but I forgot to add also postinstall script which is required after every 'yarn install' 