### PR TITLE
fix: problem with scroll to bottom of the flatList when system keyboard is opened

### DIFF
--- a/src/components/EmojiCategory.tsx
+++ b/src/components/EmojiCategory.tsx
@@ -7,6 +7,7 @@ import { KeyboardContext } from '../contexts/KeyboardContext'
 import { useKeyboardStore } from '../store/useKeyboardStore'
 import { parseEmoji } from '../utils/parseEmoji'
 import { removeSkinToneModifier } from '../utils/skinToneSelectorUtils'
+import { useKeyboard } from '../hooks/useKeyboard'
 
 const emptyEmoji: JsonEmoji = {
   emoji: '',
@@ -37,6 +38,10 @@ export const EmojiCategory = React.memo(
       styles: themeStyles,
       selectedEmojis,
     } = React.useContext(KeyboardContext)
+
+    const { keyboardHeight } = useKeyboard(true)
+
+    const contentContainerStyle = { paddingBottom: keyboardHeight }
 
     const { setKeyboardState, keyboardState } = useKeyboardStore()
 
@@ -154,6 +159,7 @@ export const EmojiCategory = React.memo(
           windowSize={16}
           maxToRenderPerBatch={5}
           keyboardShouldPersistTaps="handled"
+          contentContainerStyle={contentContainerStyle}
         />
       </View>
     )


### PR DESCRIPTION
With the system keyboard opened there was not enough bottom padding in the FlatList. Some emojis were hidden by the keyboard.

Now:
https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/37906388/88fe2834-0d5c-4ba8-ba3f-2531157ebb22

Previous:
https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/37906388/b3b32c30-9426-4545-96e9-46cb4641ffa3

