### PR TITLE
fix: adjust width

### DIFF
--- a/src/components/EmojiStaticKeyboard.tsx
+++ b/src/components/EmojiStaticKeyboard.tsx
@@ -4,7 +4,6 @@ import {
   StyleSheet,
   View,
   FlatList,
-  useWindowDimensions,
   Animated,
   SafeAreaView,
   Platform,
@@ -25,7 +24,6 @@ const isAndroid = Platform.OS === 'android'
 
 export const EmojiStaticKeyboard = React.memo(
   () => {
-    const { width } = useWindowDimensions()
     const {
       activeCategoryIndex,
       setActiveCategoryIndex,
@@ -40,6 +38,8 @@ export const EmojiStaticKeyboard = React.memo(
       styles: themeStyles,
       shouldAnimateScroll,
       enableCategoryChangeAnimation,
+      width,
+      setWidth,
     } = React.useContext(KeyboardContext)
     const { keyboardState } = useKeyboardStore()
     const flatListRef = React.useRef<FlatList>(null)
@@ -96,6 +96,7 @@ export const EmojiStaticKeyboard = React.memo(
           themeStyles.container,
           { backgroundColor: theme.container },
         ]}
+        onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
       >
         <ConditionalContainer
           condition={!disableSafeArea}

--- a/src/contexts/KeyboardContext.ts
+++ b/src/contexts/KeyboardContext.ts
@@ -93,6 +93,7 @@ export type ContextValues = {
   setActiveCategoryIndex: (index: number) => void
   numberOfColumns: number
   width: number
+  setWidth: (width: number) => void
   searchPhrase: string
   setSearchPhrase: (phrase: string) => void
   renderList: EmojisByCategory[]
@@ -179,6 +180,7 @@ export const defaultKeyboardValues: ContextValues = {
   setActiveCategoryIndex: () => {},
   numberOfColumns: 5,
   width: 0,
+  setWidth: (_width: number) => {},
   searchPhrase: '',
   setSearchPhrase: (_phrase: string) => {},
   renderList: [],

--- a/src/contexts/KeyboardProvider.tsx
+++ b/src/contexts/KeyboardProvider.tsx
@@ -27,7 +27,7 @@ type ProviderProps = Partial<KeyboardProps> &
   }
 
 export const KeyboardProvider: React.FC<ProviderProps> = React.memo((props) => {
-  const { width } = useWindowDimensions()
+  const [width, setWidth] = React.useState(useWindowDimensions().width)
   const [activeCategoryIndex, setActiveCategoryIndex] = React.useState(0)
   const [shouldAnimateScroll, setShouldAnimateScroll] = React.useState(true)
   const [searchPhrase, setSearchPhrase] = React.useState('')
@@ -181,6 +181,7 @@ export const KeyboardProvider: React.FC<ProviderProps> = React.memo((props) => {
       setActiveCategoryIndex,
       numberOfColumns: numberOfColumns.current,
       width,
+      setWidth,
       searchPhrase,
       setSearchPhrase,
       renderList,


### PR DESCRIPTION
Fixes unexpected behavior when margin/marginHorizontal is set on EmojiKeyboard parent component. 

Measure the root component width and use that instead of window width.

![image](https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/39670088/32276d7e-474e-40d9-9fa5-49a517423094)

Fixes #157 