### PR TITLE
fix: mute ts error for deepMerge

### DIFF
--- a/src/utils/deepMerge.ts
+++ b/src/utils/deepMerge.ts
@@ -9,6 +9,7 @@ export const deepMerge = <T extends object>(source: T, additional: RecursivePart
   objectKeys(additional).forEach((key) => {
     if (key && additional[key] && typeof additional[key] === 'object') {
       result[key] = deepMerge(
+        // @ts-ignore
         source[key],
         // @ts-ignore
         additional[key],


### PR DESCRIPTION
node_modules/rn-emoji-keyboard/src/utils/deepMerge.ts:12:9 - error TS2345: Argument of type 'T[keyof T]' is not assignable to parameter of type 'object'.
  Type 'T[string] | T[number] | T[symbol]' is not assignable to type 'object'.
    Type 'T[string]' is not assignable to type 'object'.

12         source[key],
           ~~~~~~~~~~~


Found 1 error in node_modules/rn-emoji-keyboard/src/utils/deepMerge.ts:12