### PR TITLE
fix: deepMerge util

### DIFF
--- a/src/__tests__/deepMerge.test.ts
+++ b/src/__tests__/deepMerge.test.ts
@@ -7,6 +7,7 @@ describe('deepMerge tests', () => {
     emoji: {
       selected: '#fff',
     },
+    category: undefined,
   }
   const newStyles = {
     container: { backgroundColor: '#000' },
@@ -36,6 +37,25 @@ describe('deepMerge tests', () => {
       emoji: {
         ...emptyStyles.emoji,
         selected: newStyles.emoji.selected,
+      },
+    })
+  })
+
+  it('should merge theme properly with undefined as property', () => {
+    const themeWithUndefined = {
+      ...newTheme,
+      search: { text: undefined },
+    }
+    expect(deepMerge(defaultTheme, themeWithUndefined)).toStrictEqual({
+      ...defaultTheme,
+      container: newTheme.container,
+      emoji: {
+        ...defaultTheme.emoji,
+        selected: newTheme.emoji.selected,
+      },
+      search: {
+        ...defaultTheme.search,
+        text: undefined,
       },
     })
   })

--- a/src/__tests__/deepMerge.test.ts
+++ b/src/__tests__/deepMerge.test.ts
@@ -1,0 +1,42 @@
+import { deepMerge } from '../utils/deepMerge'
+import { defaultTheme, emptyStyles } from '../contexts/KeyboardContext'
+
+describe('deepMerge tests', () => {
+  const newTheme = {
+    container: '#000',
+    emoji: {
+      selected: '#fff',
+    },
+  }
+  const newStyles = {
+    container: { backgroundColor: '#000' },
+    emoji: {
+      selected: {
+        backgroundColor: '#000',
+        transform: [{ rotate: '45deg' }],
+      },
+    },
+  }
+
+  it('should merge theme properly', () => {
+    expect(deepMerge(defaultTheme, newTheme)).toStrictEqual({
+      ...defaultTheme,
+      container: newTheme.container,
+      emoji: {
+        ...defaultTheme.emoji,
+        selected: newTheme.emoji.selected,
+      },
+    })
+  })
+
+  it('should merge styles properly', () => {
+    expect(deepMerge(emptyStyles, newStyles)).toStrictEqual({
+      ...emptyStyles,
+      container: newStyles.container,
+      emoji: {
+        ...emptyStyles.emoji,
+        selected: newStyles.emoji.selected,
+      },
+    })
+  })
+})

--- a/src/utils/deepMerge.ts
+++ b/src/utils/deepMerge.ts
@@ -1,21 +1,24 @@
 export type RecursivePartial<T> = Partial<{
-  [P in keyof T]: T[P] extends object ? Partial<T[P]> : T[P]
+  [P in keyof T]: T[P] extends Record<string, any> ? RecursivePartial<T[P]> : T[P]
 }>
 
-const objectKeys = <T extends object>(obj: T) => Object.keys(obj) as (keyof T)[]
+const objectKeys = <T extends Record<string, any>>(obj: T) => Object.keys(obj) as (keyof T)[]
 
-export const deepMerge = <T extends object>(source: T, additional: RecursivePartial<T>): T => {
-  const result = { ...source }
-  objectKeys(additional).forEach((key) => {
-    if (key && additional[key] && typeof additional[key] === 'object') {
-      result[key] = deepMerge(
-        source[key],
-        // @ts-ignore
-        additional[key],
-      ) as unknown as T[typeof key]
+export const deepMerge = <T extends Record<K, any>, K extends keyof T>(
+  source: T,
+  additional: RecursivePartial<T>,
+): T => {
+  const result: T = { ...source }
+  ;(objectKeys(additional) as K[]).forEach((key) => {
+    if (
+      key in source &&
+      key in additional &&
+      typeof source[key] === 'object' &&
+      typeof additional[key] === 'object'
+    ) {
+      result[key] = deepMerge(source[key], additional[key] as RecursivePartial<T[K]>)
     } else {
-      // @ts-ignore
-      result[key] = additional[key]
+      result[key] = additional[key] as T[K]
     }
   })
   return result

--- a/src/utils/deepMerge.ts
+++ b/src/utils/deepMerge.ts
@@ -2,14 +2,12 @@ export type RecursivePartial<T> = Partial<{
   [P in keyof T]: T[P] extends Record<string, any> ? RecursivePartial<T[P]> : T[P]
 }>
 
-const objectKeys = <T extends Record<string, any>>(obj: T) => Object.keys(obj) as (keyof T)[]
-
 export const deepMerge = <T extends Record<K, any>, K extends keyof T>(
   source: T,
   additional: RecursivePartial<T>,
 ): T => {
   const result: T = { ...source }
-  ;(objectKeys(additional) as K[]).forEach((key) => {
+  ;(Object.keys(additional) as K[]).forEach((key) => {
     if (
       key in source &&
       key in additional &&

--- a/src/utils/deepMerge.ts
+++ b/src/utils/deepMerge.ts
@@ -16,6 +16,7 @@ export const deepMerge = <T extends Record<K, any>, K extends keyof T>(
     ) {
       result[key] = deepMerge(source[key], additional[key] as RecursivePartial<T[K]>)
     } else {
+      if (typeof source[key] === 'object' && additional[key] === undefined) return
       result[key] = additional[key] as T[K]
     }
   })


### PR DESCRIPTION
Fixes the types and functionality of deepMerge util.

Changes:
- Fix types reported in #165 
- Introduce simple tests to deepMerge
   - merge theme
   - merge styles

---

In the previous implementation, deepMerge styles didn't work with arrays and tried to merge even nested styles. Currently, it only merges to the level that is in the source. Example:
```js
{
  container: { backgroundColor: '#000' },
  emoji: {
    selected: {
      backgroundColor: '#000',
      transform: [{ rotate: '45deg' }],
    },
  },
}
```