### PR TITLE
fix: infinite loop on category swipe

### DIFF
--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -6,12 +6,13 @@ import { CategoryItem } from './CategoryItem'
 import { exhaustiveTypeCheck } from '../utils/exhaustiveTypeCheck'
 import { defaultTheme } from '../contexts/KeyboardContext'
 
-const CATEGORY_ELEMENT_WIDTH = 37
+export const CATEGORY_ELEMENT_WIDTH = 37
 
 const Separator = () => <View style={styles.separator} />
 
 type Props = {
   scrollNav?: Animated.Value
+  scrollEmojiCategoryListToIndex: (index: number) => void
 }
 
 export const Categories = (p: Props) => {
@@ -27,9 +28,13 @@ export const Categories = (p: Props) => {
   } = React.useContext(KeyboardContext)
 
   const scrollNav = React.useRef(new Animated.Value(0)).current
-  const handleScrollToCategory = React.useCallback(() => {
-    setShouldAnimateScroll(enableCategoryChangeAnimation)
-  }, [setShouldAnimateScroll, enableCategoryChangeAnimation])
+  const handleScrollToCategory = React.useCallback(
+    (index: number) => {
+      setShouldAnimateScroll(enableCategoryChangeAnimation)
+      p.scrollEmojiCategoryListToIndex(index)
+    },
+    [setShouldAnimateScroll, enableCategoryChangeAnimation, p],
+  )
 
   const renderItem = React.useCallback(
     ({ item, index }: { item: CategoryNavigationItem; index: number }) => (

--- a/src/components/CategoryItem.tsx
+++ b/src/components/CategoryItem.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react'
 import { View, StyleSheet, TouchableOpacity } from 'react-native'
 import { KeyboardContext } from '../contexts/KeyboardContext'
-import type { CategoryNavigationItem, CategoryTypes } from '../types'
+import type { CategoryNavigationItem } from '../types'
 import { Icon } from './Icon'
 
 type CategoryItemProps = {
   item: CategoryNavigationItem
   index: number
-  handleScrollToCategory: (category: CategoryTypes) => void
+  handleScrollToCategory: (index: number) => void
 }
 
 export const CategoryItem = ({ item, index, handleScrollToCategory }: CategoryItemProps) => {
   const { activeCategoryIndex, theme, setActiveCategoryIndex } = React.useContext(KeyboardContext)
 
   const handleSelect = () => {
-    handleScrollToCategory(item.category)
+    handleScrollToCategory(index)
     setActiveCategoryIndex(index)
   }
 

--- a/src/components/EmojiStaticKeyboard.tsx
+++ b/src/components/EmojiStaticKeyboard.tsx
@@ -13,13 +13,12 @@ import {
 import { type EmojisByCategory } from '../types'
 import { EmojiCategory } from './EmojiCategory'
 import { KeyboardContext } from '../contexts/KeyboardContext'
-import { Categories } from './Categories'
+import { Categories, CATEGORY_ELEMENT_WIDTH } from './Categories'
 import { SearchBar } from './SearchBar'
 import { useKeyboardStore } from '../store/useKeyboardStore'
 import { ConditionalContainer } from './ConditionalContainer'
 import { SkinTones } from './SkinTones'
 
-const CATEGORY_ELEMENT_WIDTH = 37
 const isAndroid = Platform.OS === 'android'
 
 export const EmojiStaticKeyboard = React.memo(
@@ -85,13 +84,19 @@ export const EmojiStaticKeyboard = React.memo(
       [activeCategoryIndex],
     )
 
+    const scrollEmojiCategoryListToIndex = React.useCallback(
+      (index: number) => {
+        flatListRef.current?.scrollToIndex({
+          index,
+          animated: shouldAnimateScroll && enableCategoryChangeAnimation,
+        })
+      },
+      [enableCategoryChangeAnimation, shouldAnimateScroll],
+    )
+
     React.useEffect(() => {
-      flatListRef.current?.scrollToIndex({
-        index: activeCategoryIndex,
-        animated: shouldAnimateScroll && enableCategoryChangeAnimation,
-      })
       setKeyboardScrollOffsetY(0)
-    }, [activeCategoryIndex, enableCategoryChangeAnimation, shouldAnimateScroll])
+    }, [activeCategoryIndex])
 
     const keyExtractor = React.useCallback((item: EmojisByCategory) => item.title, [])
     const scrollNav = React.useRef(new Animated.Value(0)).current
@@ -155,7 +160,10 @@ export const EmojiStaticKeyboard = React.memo(
               keyboardShouldPersistTaps="handled"
               onMomentumScrollEnd={onScrollEnd}
             />
-            <Categories scrollNav={enableCategoryChangeGesture ? scrollNav : undefined} />
+            <Categories
+              scrollEmojiCategoryListToIndex={scrollEmojiCategoryListToIndex}
+              scrollNav={enableCategoryChangeGesture ? scrollNav : undefined}
+            />
             <SkinTones keyboardScrollOffsetY={keyboardScrollOffsetY} />
           </>
         </ConditionalContainer>


### PR DESCRIPTION
This PR fixes infinite loop on quick emoji list scroll behavior reported in issue https://github.com/TheWidlarzGroup/rn-emoji-keyboard/issues/159

Changes:
- moved logic for scrolling emoji categories from useEffect hook to separate method 
- passed it into handleScrollToCategory method in Categories component

---
In the previous implementation, after scrolling between EmojiCategories using gesture, when `setActiveCategory` was called inside `onScrollEnd` method, `useEffect` callback with `scrollToIndex` was fired with `activeCategoryIndex` that the list was already at. Quick scrolling back and forth with gesture was causing infinite state updates between current and previous `activeCategoryIndex`es.  To fix that behavior while leaving ability to browse EmojiCategories using CategoryItem press `scrollToIndex` is now called directly inside `CategoryItem`