### PR TITLE
docs: replace homepage with an official documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "bugs": {
     "url": "https://github.com/TheWidlarzGroup/rn-emoji-keyboard/issues"
   },
-  "homepage": "https://github.com/TheWidlarzGroup/rn-emoji-keyboard#readme",
+  "homepage": "https://thewidlarzgroup.github.io/rn-emoji-keyboard",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"


### PR DESCRIPTION
After the merge, the homepage on [npmjs.org](https://www.npmjs.com/package/rn-emoji-keyboard) will be replaced with an official documentation.

<img width="1710" alt="Screenshot" src="https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/91079590/ce045b03-46d1-40e9-9111-226a86de54c9">
