### PR TITLE
docs: type imports

### DIFF
--- a/docs/docs/documentation/Examples/selected_emojis.md
+++ b/docs/docs/documentation/Examples/selected_emojis.md
@@ -13,7 +13,7 @@ To use this feature you have to pass a [selectedEmojis](/docs/api/modal#selected
 When you provide selectedEmojis array, `onEmojiSelected` callback will also return `alreadySelected` boolean indicating whether pressed emoji was already selected or not.
 
 ```jsx
-import EmojiPicker, { EmojiType } from 'rn-emoji-keyboard';
+import EmojiPicker, { type EmojiType } from 'rn-emoji-keyboard';
 
 const ExampleComponent = () => {
   // ...

--- a/docs/docs/documentation/start.md
+++ b/docs/docs/documentation/start.md
@@ -22,7 +22,7 @@ npm install rn-emoji-keyboard
 ## Usage
 
 ```js
-import EmojiPicker from 'rn-emoji-keyboard'
+import EmojiPicker, { type EmojiType } from 'rn-emoji-keyboard'
 
 export default function App() {
   const [isOpen, setIsOpen] = React.useState<boolean>(false)


### PR DESCRIPTION
Add missing `type` keyword and `EmojiType` import to docs example