### PR TITLE
fix: categories index change

### DIFF
--- a/src/components/EmojiStaticKeyboard.tsx
+++ b/src/components/EmojiStaticKeyboard.tsx
@@ -42,6 +42,7 @@ export const EmojiStaticKeyboard = React.memo(
     } = React.useContext(KeyboardContext)
     const { keyboardState } = useKeyboardStore()
     const flatListRef = React.useRef<FlatList>(null)
+    const hasMomentumBegan = React.useRef(false)
 
     const getItemLayout = React.useCallback(
       (_: EmojisByCategory[] | null | undefined, index: number) => ({
@@ -109,10 +110,18 @@ export const EmojiStaticKeyboard = React.memo(
       [scrollNav, width],
     )
 
-    const onScrollEnd = React.useCallback(
+    const onMomentumScrollBegin = React.useCallback(() => {
+      hasMomentumBegan.current = true
+    }, [])
+
+    const onMomentumScrollEnd = React.useCallback(
       (el: NativeSyntheticEvent<NativeScrollEvent>) => {
+        if (!hasMomentumBegan.current) return
+
         const index = el.nativeEvent.contentOffset.x / width
         setActiveCategoryIndex(Math.round(index))
+
+        hasMomentumBegan.current = false
       },
       [setActiveCategoryIndex, width],
     )
@@ -169,7 +178,8 @@ export const EmojiStaticKeyboard = React.memo(
               maxToRenderPerBatch={1}
               onScroll={handleScroll}
               keyboardShouldPersistTaps="handled"
-              onMomentumScrollEnd={onScrollEnd}
+              onMomentumScrollBegin={onMomentumScrollBegin}
+              onMomentumScrollEnd={onMomentumScrollEnd}
             />
             <Categories
               scrollEmojiCategoryListToIndex={scrollEmojiCategoryListToIndex}


### PR DESCRIPTION
## Issue

After recent changes, whenever a user changes the category using the category icons one by one (quickly), picker would change category's index twice (e.g. 0->1->2->1->2 whereas it should only be 0->1->2) - 1) in onPress handler on a category icon and 2) with onMomentumScroll handler.

## Fix

Category needs to be changed only with one method at a time thus skipping onMomentumScrollEnd handler whenever the momentum did not start helped (adding additional onMomentumScrollBegin handler was required)

## Steps to reproduce the issue

1. open an emoji picker with category icons either on top or bottom
2. change category by pressing a category icon
3. quickly repeat it with another category

### Before:

https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/44443723/2429fdf6-147c-4d50-b477-079631511c27

### After:
https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/44443723/45405415-c44a-4a37-9de2-39ad2129ab5d

### Android is functioning ok as well:
https://github.com/TheWidlarzGroup/rn-emoji-keyboard/assets/44443723/44197349-b1be-4231-8bdc-a50194d0bd9f



