### PR TITLE
Update selected_emojis.md

### DIFF
--- a/docs/docs/documentation/Examples/selected_emojis.md
+++ b/docs/docs/documentation/Examples/selected_emojis.md
@@ -24,8 +24,8 @@ const ExampleComponent = () => {
 
     // Remove or add pressed emoji to the currently selected array
     if (emoji.alreadySelected)
-      setCurrentlySelected((prev) => prev.filter((a) => a !== emoji.name))
-    else setCurrentlySelected((prev) => [...prev, emoji.name])
+      setCurrentlySelectedEmojis((prev) => prev.filter((a) => a !== emoji.name))
+    else setCurrentlySelectedEmojis((prev) => [...prev, emoji.name])
 
   }
 
@@ -34,7 +34,7 @@ const ExampleComponent = () => {
       open={isOpen}
       onClose={handleOnClose}
       onEmojiSelected={handleOnEmojiSelected}
-      selectedEmojis={currentlySelected}
+      selectedEmojis={currentlySelectedEmojis}
     />
   )
 }


### PR DESCRIPTION
In the original documentation, there was an inconsistency in the use of the useState hook. The state variable was defined as currentlySelectedEmojis using const [currentlySelectedEmojis, setCurrentlySelectedEmojis] = useState([]), but in the rest of the code, it was incorrectly referenced as currentlySelected and setCurrentlySelected. This mismatch could lead to confusion and potential bugs, as the state variable and its updater function were not correctly named.

To resolve this issue, I corrected the naming of the state variable and its updater function. The correct code should consistently use currentlySelectedEmojis and setCurrentlySelectedEmojis throughout. This change ensures that the code is more readable and less prone to errors.


```
import EmojiPicker, { type EmojiType } from 'rn-emoji-keyboard';

const ExampleComponent = () => {
  const [currentlySelectedEmojis, setCurrentlySelectedEmojis] = useState([]);

  const handleOnEmojiSelected = (emoji: EmojiType) => {
    // Your on-select logic

    // Remove or add pressed emoji to the currently selected array
    if (emoji.alreadySelected) {
      setCurrentlySelectedEmojis((prev) => prev.filter((a) => a !== emoji.name));
    } else {
      setCurrentlySelectedEmojis((prev) => [...prev, emoji.name]);
    }
  };

  return (
    <EmojiPicker
      open={isOpen}
      onClose={handleOnClose}
      onEmojiSelected={handleOnEmojiSelected}
      selectedEmojis={currentlySelectedEmojis}
    />
  );
};

```

This update eliminates the naming inconsistency and aligns the state variable with its intended usage.