### PR TITLE
feat: custom emoji text style

### DIFF
--- a/docs/docs/api/styles.md
+++ b/docs/docs/api/styles.md
@@ -60,6 +60,6 @@ Set styles of the searchBar component. You can pass different styles for the con
 
 ### `emoji`
 
-Set styles of the emoji component. You can pass styles for selected state.
+Set styles of the emoji component. You can pass styles for selected state, and the general text style (e.g. for custom fonts).
 
-<ApiTable typeVal='{ selected: ViewStyle }' defaultVal='{ selected: {} }'/>
+<ApiTable typeVal='{ selected: ViewStyle, text: TextStyle }' defaultVal='{ selected: {}, text: {} }'/>

--- a/src/components/EmojiCategory.tsx
+++ b/src/components/EmojiCategory.tsx
@@ -115,6 +115,7 @@ export const EmojiCategory = React.memo(
             emojiSize={emojiSize}
             onPress={handleEmojiPress}
             onLongPress={handleEmojiLongPress}
+            themeStyles={themeStyles}
             selectedEmojiStyle={
               isSelected
                 ? [
@@ -134,7 +135,7 @@ export const EmojiCategory = React.memo(
         handleEmojiPress,
         handleEmojiLongPress,
         theme.emoji.selected,
-        themeStyles.emoji.selected,
+        themeStyles,
       ],
     )
 

--- a/src/components/SingleEmoji.tsx
+++ b/src/components/SingleEmoji.tsx
@@ -9,6 +9,8 @@ import {
   type StyleProp,
 } from 'react-native'
 import type { EmojiSizes, JsonEmoji } from '../types'
+import type { Styles } from '../contexts/KeyboardContext'
+import type { RecursivePartial } from '../utils/deepMerge'
 
 type Props = {
   item: JsonEmoji
@@ -18,6 +20,7 @@ type Props = {
   onLongPress: (emoji: JsonEmoji, emojiIndex: number, emojiSizes: EmojiSizes) => void
   selectedEmojiStyle?: StyleProp<ViewStyle>
   isSelected?: boolean
+  themeStyles: RecursivePartial<Styles>
 }
 
 export const SingleEmoji = React.memo(
@@ -37,7 +40,9 @@ export const SingleEmoji = React.memo(
         style={styles.container}
       >
         <View pointerEvents={'none'} style={[styles.emojiWrapper, p.selectedEmojiStyle]}>
-          <Text style={[styles.emoji, { fontSize: p.emojiSize }]}>{p.item.emoji}</Text>
+          <Text style={[styles.emoji, { fontSize: p.emojiSize }, p.themeStyles.emoji?.text]}>
+            {p.item.emoji}
+          </Text>
         </View>
       </TouchableOpacity>
     )

--- a/src/contexts/KeyboardContext.ts
+++ b/src/contexts/KeyboardContext.ts
@@ -31,6 +31,7 @@ export type Styles = {
   }
   emoji: {
     selected: ViewStyle
+    text: TextStyle
   }
 }
 
@@ -128,6 +129,7 @@ export const emptyStyles: Styles = {
   knob: {},
   emoji: {
     selected: {},
+    text: {},
   },
 }
 export const defaultTheme: Theme = {


### PR DESCRIPTION
This small PR adds a text style param for the single emoji component.

This change is to the end of supporting custom fonts. For example, here is RN Emoji Keyboard with NotoEmoji:

```
...
<EmojiKeyboard
  styles={{
    emoji: {
      text: {
        fontFamily: "NotoEmoji-Bold",
        fontSize: 32,
        color: "#10b98f"
      }
    }
  }}
...
>
```

![IMG_9114](https://github.com/user-attachments/assets/745ac1e5-fc27-4087-a7a2-2dd7f8964ede)
