### PR TITLE
fix: replace variation selector when applying skin tone

### DIFF
--- a/src/__tests__/applySkinTone.test.ts
+++ b/src/__tests__/applySkinTone.test.ts
@@ -1,0 +1,32 @@
+import { applySkinTone } from '../utils/skinToneSelectorUtils'
+
+const codepoints = (s: string) =>
+  Array.from(s)
+    .map((c) => `U+${c.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0')}`)
+    .join(' ')
+
+const MEDIUM_DARK = String.fromCodePoint(0x1f3fe) // 🏾
+
+describe('applySkinTone', () => {
+  it('appends the tone to a plain base emoji', () => {
+    // 👍 (1F44D) → 👍🏾 (1F44D 1F3FE)
+    expect(codepoints(applySkinTone('👍', MEDIUM_DARK))).toBe('U+1F44D U+1F3FE')
+  })
+
+  it('replaces a trailing variation selector rather than following it', () => {
+    // ☝️ (261D FE0F) → ☝🏾 (261D 1F3FE), NOT 261D 1F3FE FE0F
+    expect(codepoints(applySkinTone('☝️', MEDIUM_DARK))).toBe('U+261D U+1F3FE')
+  })
+
+  it('does not leave a VS16 after the skin-tone modifier', () => {
+    expect(applySkinTone('☝️', MEDIUM_DARK)).not.toContain(String.fromCodePoint(0xfe0f))
+  })
+
+  it('inserts the tone before a ZWJ in a ZWJ sequence', () => {
+    // 1F575 FE0F 200D 2640 FE0F — the tone must precede the ZWJ.
+    const detective = '🕵️‍♀️'
+    const result = applySkinTone(detective, MEDIUM_DARK)
+    const zwj = String.fromCodePoint(0x200d)
+    expect(result.indexOf(MEDIUM_DARK)).toBeLessThan(result.indexOf(zwj))
+  })
+})

--- a/src/contexts/KeyboardProvider.tsx
+++ b/src/contexts/KeyboardProvider.tsx
@@ -15,9 +15,7 @@ import {
   skinTones,
   generateToneSelectorFunnelPosition,
   generateToneSelectorPosition,
-  insertAtCertainIndex,
-  variantSelector,
-  zeroWidthJoiner,
+  applySkinTone,
 } from '../utils/skinToneSelectorUtils'
 import { deepMerge } from '../utils/deepMerge'
 
@@ -71,35 +69,13 @@ export const KeyboardProvider: React.FC<ProviderProps> = React.memo((props) => {
 
       const EXTRA_SEARCH_TOP = props.enableSearchBar || props.categoryPosition === 'top' ? 50 : 0
 
-      const splittedEmoji = emoji.emoji.split('')
-      const ZWJIndex = splittedEmoji.findIndex((a) => a === zeroWidthJoiner)
-      const selectorIndex = splittedEmoji.findIndex((a) => a === variantSelector)
-      const modifiedEmojis = skinTones.map((tone) => {
-        const basicEmojiData = {
-          index: tone.name,
-          name: emoji.name,
-          v: emoji.v,
-          toneEnabled: true,
-        }
-        // Check for emojis special signs which might break tone modify
-        switch (true) {
-          case ZWJIndex > 0:
-            return {
-              ...basicEmojiData,
-              emoji: insertAtCertainIndex(splittedEmoji, ZWJIndex, tone.color).join(''),
-            }
-          case selectorIndex > 0:
-            return {
-              ...basicEmojiData,
-              emoji: insertAtCertainIndex(splittedEmoji, selectorIndex, tone.color).join(''),
-            }
-          default:
-            return {
-              ...basicEmojiData,
-              emoji: emoji.emoji + tone.color,
-            }
-        }
-      })
+      const modifiedEmojis = skinTones.map((tone) => ({
+        index: tone.name,
+        name: emoji.name,
+        v: emoji.v,
+        toneEnabled: true,
+        emoji: applySkinTone(emoji.emoji, tone.color),
+      }))
 
       const skinTonePosition = generateToneSelectorPosition(
         numberOfColumns.current,

--- a/src/utils/skinToneSelectorUtils.ts
+++ b/src/utils/skinToneSelectorUtils.ts
@@ -83,6 +83,30 @@ export const removeSkinToneModifier = (emoji: string) => {
   return emojiCopy
 }
 
+// Applies a Fitzpatrick skin-tone modifier to a base emoji, producing a
+// canonical Unicode sequence.
+//
+// The modifier is inserted before a ZWJ (so it tones the leading component of
+// a ZWJ sequence), and *replaces* a variation selector (VS16, U+FE0F) rather
+// than following it: the modifier already forces emoji presentation, so a
+// trailing VS16 is non-conformant and can fail strict emoji validation (e.g.
+// index-pointing-up with a tone must be 261D 1F3FE, not 261D 1F3FE FE0F).
+export const applySkinTone = (emoji: string, tone: string) => {
+  const parts = emoji.split('')
+
+  const zwjIndex = parts.findIndex((a) => a === zeroWidthJoiner)
+  if (zwjIndex > 0) {
+    return insertAtCertainIndex(parts, zwjIndex, tone).join('')
+  }
+
+  const selectorIndex = parts.findIndex((a) => a === variantSelector)
+  if (selectorIndex > 0) {
+    return [...parts.slice(0, selectorIndex), tone, ...parts.slice(selectorIndex + 1)].join('')
+  }
+
+  return emoji + tone
+}
+
 export const skinTones = [
   {
     name: 'light_skin_tone',


### PR DESCRIPTION
## Problem

When a skin tone is applied to a base emoji whose default form carries a variation selector (VS16, `U+FE0F`), the picker **inserts** the Fitzpatrick modifier *before* the VS16, producing `base + tone + VS16` — e.g. `261D 1F3FE FE0F` for a toned ☝ (index pointing up).

Per Unicode, a skin-tone modifier already forces emoji presentation, so a trailing VS16 is non-conformant (the fully-qualified form is `base + tone`, `261D 1F3FE`). The result renders identically on most platforms but can be **rejected by strict emoji validation** on servers/APIs — we hit this as a user-facing "invalid emoji" error when such reactions reached our backend.

This affects every skin-toned variant of any base emoji whose default form includes a VS16 (☝️, ✌️, ☺️, ✍️, …).

## Fix

- Extract tone application into a small pure helper, `applySkinTone(emoji, tone)`, in `skinToneSelectorUtils.ts`.
- For a VS16-bearing base, **replace** the selector with the skin-tone modifier instead of inserting before it → canonical `261D 1F3FE`.
- ZWJ-sequence handling (tone inserted before the ZWJ) is unchanged.
- `generateEmojiTones` in `KeyboardProvider.tsx` now calls the helper, replacing the inline `switch` and dropping three now-unused imports.
- Adds `src/__tests__/applySkinTone.test.ts` covering: plain base, VS16 replacement, no trailing VS16, and ZWJ ordering.

## Verification

`yarn lint` and `yarn jest` pass (new suite included). `yarn typecheck` is clean for `src/` (the only pre-existing errors are in `example/` from optional peer deps not installed locally).

## Before / after

For ☝️ + medium-dark tone:

- before: `U+261D U+1F3FE U+FE0F` (non-conformant)
- after: `U+261D U+1F3FE` (canonical)